### PR TITLE
chore: fix unlock state workaround

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@dimensiondev/metamask-extension-provider",
-  "version": "3.0.0",
+  "version": "3.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dimensiondev/metamask-extension-provider",
-      "version": "3.0.0",
+      "version": "3.0.2",
       "license": "MIT",
       "dependencies": {
         "detect-browser": "^3.0.0",
         "extension-port-stream": "^1.0.0",
-        "inpage-provider-7": "npm:@metamask/inpage-provider@^7.0.0",
-        "inpage-provider-8": "npm:@metamask/inpage-provider@^8.0.3"
+        "inpage-provider-7": "npm:@zhouhancheng/inpage-provider@^7.0.1",
+        "inpage-provider-8": "npm:@zhouhancheng/inpage-provider@^8.0.4"
       },
       "devDependencies": {
         "web3": "^1.3.3"
@@ -2065,16 +2065,15 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "node_modules/inpage-provider-7": {
-      "name": "@metamask/inpage-provider",
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@metamask/inpage-provider/-/inpage-provider-7.0.0.tgz",
-      "integrity": "sha512-5hR9FOwGCv6WTehWdV71M/LrPXUemn/CdlD18M96t03t/sfHP96dTtv0xV3fTO1N1RLhRNIDzowkDWYpKlb5VA==",
-      "deprecated": "The MetaMask wallet applications only support ^8.0.0",
+      "name": "@zhouhancheng/inpage-provider",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@zhouhancheng/inpage-provider/-/inpage-provider-7.0.1.tgz",
+      "integrity": "sha512-Z3pnoFwO/CIWWPzrsYofFjPiK2q3lTbgqMpJ6/uAq7EkH4noTgCbIZWJbPFKktbxf0TMKB36+RT6npfnlEnBow==",
       "dependencies": {
         "eth-rpc-errors": "^2.1.1",
         "fast-deep-equal": "^2.0.1",
         "is-stream": "^2.0.0",
-        "json-rpc-engine": "^5.2.0",
+        "json-rpc-engine": "^6.1.0",
         "json-rpc-middleware-stream": "^2.1.1",
         "obj-multiplex": "^1.0.0",
         "obs-store": "^4.0.3",
@@ -2090,23 +2089,6 @@
         "fast-safe-stringify": "^2.0.6"
       }
     },
-    "node_modules/inpage-provider-7/node_modules/json-rpc-engine": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-5.4.0.tgz",
-      "integrity": "sha512-rAffKbPoNDjuRnXkecTjnsE3xLLrb00rEkdgalINhaYVYIxDwWtvYBr9UFbhTvPB1B2qUOLoFd/cV6f4Q7mh7g==",
-      "dependencies": {
-        "eth-rpc-errors": "^3.0.0",
-        "safe-event-emitter": "^1.0.1"
-      }
-    },
-    "node_modules/inpage-provider-7/node_modules/json-rpc-engine/node_modules/eth-rpc-errors": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eth-rpc-errors/-/eth-rpc-errors-3.0.0.tgz",
-      "integrity": "sha512-iPPNHPrLwUlR9xCSYm7HHQjWBasor3+KZfRvwEWxMz3ca0yqnlBeJrnyphkGIXZ4J7AMAaOLmwy4AWhnxOiLxg==",
-      "dependencies": {
-        "fast-safe-stringify": "^2.0.6"
-      }
-    },
     "node_modules/inpage-provider-7/node_modules/json-rpc-middleware-stream": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/json-rpc-middleware-stream/-/json-rpc-middleware-stream-2.1.1.tgz",
@@ -2117,10 +2099,10 @@
       }
     },
     "node_modules/inpage-provider-8": {
-      "name": "@metamask/inpage-provider",
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/@metamask/inpage-provider/-/inpage-provider-8.0.3.tgz",
-      "integrity": "sha512-pj9tGNoS1edohuRJzxOuILRqRrQTdgu5mJwMwa9wuOZIMQLFZtr3g2T6vayPBwoNkE1FzLhs/osUqaVQDRfDvQ==",
+      "name": "@zhouhancheng/inpage-provider",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@zhouhancheng/inpage-provider/-/inpage-provider-8.0.4.tgz",
+      "integrity": "sha512-Stw47QFos4RaEjep2J84xFvi2GVmKCQbweLQwdAIRIi5x7lSmQ7RI3T2pci1fFblcaqaWmauK3C59ZFdexc99w==",
       "dependencies": {
         "@metamask/object-multiplex": "^1.1.0",
         "@metamask/safe-event-emitter": "^2.0.0",
@@ -5899,14 +5881,14 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "inpage-provider-7": {
-      "version": "npm:@metamask/inpage-provider@7.0.0",
-      "resolved": "https://registry.npmjs.org/@metamask/inpage-provider/-/inpage-provider-7.0.0.tgz",
-      "integrity": "sha512-5hR9FOwGCv6WTehWdV71M/LrPXUemn/CdlD18M96t03t/sfHP96dTtv0xV3fTO1N1RLhRNIDzowkDWYpKlb5VA==",
+      "version": "npm:@zhouhancheng/inpage-provider@7.0.1",
+      "resolved": "https://registry.npmjs.org/@zhouhancheng/inpage-provider/-/inpage-provider-7.0.1.tgz",
+      "integrity": "sha512-Z3pnoFwO/CIWWPzrsYofFjPiK2q3lTbgqMpJ6/uAq7EkH4noTgCbIZWJbPFKktbxf0TMKB36+RT6npfnlEnBow==",
       "requires": {
         "eth-rpc-errors": "^2.1.1",
         "fast-deep-equal": "^2.0.1",
         "is-stream": "^2.0.0",
-        "json-rpc-engine": "^5.2.0",
+        "json-rpc-engine": "^6.1.0",
         "json-rpc-middleware-stream": "^2.1.1",
         "obj-multiplex": "^1.0.0",
         "obs-store": "^4.0.3",
@@ -5922,25 +5904,6 @@
             "fast-safe-stringify": "^2.0.6"
           }
         },
-        "json-rpc-engine": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-5.4.0.tgz",
-          "integrity": "sha512-rAffKbPoNDjuRnXkecTjnsE3xLLrb00rEkdgalINhaYVYIxDwWtvYBr9UFbhTvPB1B2qUOLoFd/cV6f4Q7mh7g==",
-          "requires": {
-            "eth-rpc-errors": "^3.0.0",
-            "safe-event-emitter": "^1.0.1"
-          },
-          "dependencies": {
-            "eth-rpc-errors": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/eth-rpc-errors/-/eth-rpc-errors-3.0.0.tgz",
-              "integrity": "sha512-iPPNHPrLwUlR9xCSYm7HHQjWBasor3+KZfRvwEWxMz3ca0yqnlBeJrnyphkGIXZ4J7AMAaOLmwy4AWhnxOiLxg==",
-              "requires": {
-                "fast-safe-stringify": "^2.0.6"
-              }
-            }
-          }
-        },
         "json-rpc-middleware-stream": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/json-rpc-middleware-stream/-/json-rpc-middleware-stream-2.1.1.tgz",
@@ -5953,9 +5916,9 @@
       }
     },
     "inpage-provider-8": {
-      "version": "npm:@metamask/inpage-provider@8.0.3",
-      "resolved": "https://registry.npmjs.org/@metamask/inpage-provider/-/inpage-provider-8.0.3.tgz",
-      "integrity": "sha512-pj9tGNoS1edohuRJzxOuILRqRrQTdgu5mJwMwa9wuOZIMQLFZtr3g2T6vayPBwoNkE1FzLhs/osUqaVQDRfDvQ==",
+      "version": "npm:@zhouhancheng/inpage-provider@8.0.4",
+      "resolved": "https://registry.npmjs.org/@zhouhancheng/inpage-provider/-/inpage-provider-8.0.4.tgz",
+      "integrity": "sha512-Stw47QFos4RaEjep2J84xFvi2GVmKCQbweLQwdAIRIi5x7lSmQ7RI3T2pci1fFblcaqaWmauK3C59ZFdexc99w==",
       "requires": {
         "@metamask/object-multiplex": "^1.1.0",
         "@metamask/safe-event-emitter": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dimensiondev/metamask-extension-provider",
-  "version": "3.0.0",
+  "version": "3.0.2",
   "description": "A module for allowing a WebExtension to access the web3 provider from an installed MetaMask instance.",
   "main": "index.js",
   "type": "index.d.ts",
@@ -23,8 +23,8 @@
   "dependencies": {
     "detect-browser": "^3.0.0",
     "extension-port-stream": "^1.0.0",
-    "inpage-provider-7": "npm:@metamask/inpage-provider@^7.0.0",
-    "inpage-provider-8": "npm:@metamask/inpage-provider@^8.0.3"
+    "inpage-provider-7": "npm:@zhouhancheng/inpage-provider@^7.0.1",
+    "inpage-provider-8": "npm:@zhouhancheng/inpage-provider@^8.0.4"
   },
   "devDependencies": {
     "web3": "^1.3.3"


### PR DESCRIPTION
See https://github.com/MetaMask/metamask-extension/issues/10368

Just remove the `if` check of is `unlocked` state the same, fixes the problem we encountered.

```ts
if (isUnlocked !== this._state.isUnlocked) {
```

Using our workaround pkg: https://www.npmjs.com/package/@zhouhancheng/inpage-provider, code:

[@zhouhancheng/inpage-provider@^7.0.1](https://github.com/zhouhanseng/inpage-provider/tree/hancheng/7.0.0)

[@zhouhancheng/inpage-provider@^8.0.4](https://github.com/zhouhanseng/inpage-provider/tree/hancheng/8.0.4)